### PR TITLE
feat(mitten): add `@ombro/mitten` package

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,8 @@
 {
   "extends": ["@ombro/eslint-config-typescript"],
   "rules": {
-    "@typescript-eslint/no-var-requires": "off"
+    "@typescript-eslint/no-var-requires": "off",
+    "@typescript-eslint/no-non-null-assertion": "off",
+    "@typescript-eslint/no-explicit-any": "off"
   }
 }

--- a/.tpl/README.md
+++ b/.tpl/README.md
@@ -1,6 +1,8 @@
 # {{PACKAGE_NAME}}
 
-![npm package](https://badgen.net/npm/v/{{PACKAGE_NAME}})
+[![npm package](https://badgen.net/npm/v/{{PACKAGE_NAME}})](https://npmjs.com/package/{{PACKAGE_NAME}})
+
+English | [简体中文](./README_zh.md)
 
 TODO
 

--- a/.tpl/README_zh.md
+++ b/.tpl/README_zh.md
@@ -1,6 +1,8 @@
 # {{PACKAGE_NAME}}
 
-![npm package](https://badgen.net/npm/v/{{PACKAGE_NAME}})
+[![npm package](https://badgen.net/npm/v/{{PACKAGE_NAME}})](https://npmjs.com/package/{{PACKAGE_NAME}})
+
+[English](./README.md) | 简体中文
 
 TODO
 

--- a/ombro.code-workspace
+++ b/ombro.code-workspace
@@ -13,6 +13,10 @@
       "path": "packages/logger"
     },
     {
+      "name": "📦 @ombro/mitten",
+      "path": "packages/mitten"
+    },
+    {
       "name": "📦 @ombro/tsconfig",
       "path": "packages/tsconfig"
     }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/node": "^18.15.5",
     "@typescript-eslint/eslint-plugin": "^5.56.0",
     "@typescript-eslint/parser": "^5.56.0",
-    "@vitest/coverage-c8": "^0.29.7",
+    "@vitest/coverage-c8": "^0.31.4",
     "commitizen": "^4.3.0",
     "cz-conventional-changelog": "^3.3.0",
     "eslint": "^8.36.0",
@@ -62,7 +62,7 @@
     "typescript": "^5.1.3",
     "vite": "^4.2.1",
     "vite-plugin-dts": "^2.1.0",
-    "vitest": "^0.29.7",
+    "vitest": "^0.31.4",
     "vue-tsc": "^1.6.5"
   }
 }

--- a/packages/mitten/README.md
+++ b/packages/mitten/README.md
@@ -1,15 +1,120 @@
 # @ombro/mitten
 
-![npm package](https://badgen.net/npm/v/@ombro/mitten)
+[![npm package](https://badgen.net/npm/v/@ombro/mitten)](https://npmjs.com/package/@ombro/mitten)
 
-TODO
+Mitten is a lightweight event emitter library for TypeScript that allows you to create, manage, and emit custom events.
 
-## Install
+## Installation
+
+Use your favorite package manager to install it:
 
 ```sh
-$ npm install @ombro/mitten
+npm install @ombro/mitten
+# or
+pnpm add @ombro/mitten
 ```
 
 ## Usage
 
-TODO
+### Creating an Emitter
+
+To create an emitter, you can use the `mitten` function. It takes an optional `EventHandlerMap` object as an argument, which is a map of event types and their corresponding event object.
+
+```ts
+import mitten from '@ombro/mitten'
+
+type MyEvents = {
+  foo: string
+  bar: number
+}
+
+const emitter = mitten<MyEvents>()
+```
+
+### Registering Event Handlers
+
+To register an event handler, use the `on` method of the emitter. It takes two arguments: the event type to listen for, and the callback function to execute in response to the event.
+
+```ts
+emitter.on('foo', (event) => {
+  console.log(`Received event with value: ${event}`)
+})
+```
+
+To register a wildcard event handler that will execute for all events, use the `on` method with a `'*'` type and a callback that takes two arguments: the event type and the event object.
+
+```ts
+emitter.on('*', (type, event) => {
+  console.log(`Received ${type} event with value: ${event}`)
+})
+```
+
+### Emitting Events
+
+To emit an event, use the `emit` method of the emitter. It takes two arguments: the event type to emit, and the event object to pass to the event handlers.
+
+```ts
+emitter.emit('foo', 'hello world')
+```
+
+If you need to emit an event with an undefined value, pass `undefined` as the second argument to `emit`. You can also omit the second argument entirely if the event type has an optional value.
+
+```ts
+type MyEvents = {
+  foo: string
+  bar?: number
+}
+
+emitter.emit('foo', 'hello world')
+emitter.emit('bar')
+```
+
+### Unregistering Event Handlers
+
+To unregister an event handler, use the `off` method of the emitter. It takes two arguments: the event type to unregister the handler from, and the optional callback function to remove.
+
+```ts
+const handler = (event: string) => {
+  console.log(`Received event with value: ${event}`)
+}
+
+emitter.on('foo', handler)
+
+// Unregister a specific handler
+emitter.off('foo', handler)
+
+// Unregister all handlers for a specific event type
+emitter.off('foo')
+
+// Unregister all handlers for wildcard event types
+emitter.off('*')
+```
+
+## Example
+
+```ts
+import mitten from '@ombro/mitten'
+
+type MyEvents = {
+  foo: string
+  bar?: number
+}
+
+const emitter = mitten<MyEvents>()
+
+emitter.on('foo', (event) => {
+  console.log(`Received foo event with value: ${event}`)
+})
+
+emitter.on('bar', (event) => {
+  console.log(`Received bar event with value: ${event}`)
+})
+
+emitter.on('*', (type, event) => {
+  console.log(`Received ${type} event with value: ${event}`)
+})
+
+emitter.emit('foo', 'hello world')
+emitter.emit('bar', 42)
+emitter.emit('bar')
+```

--- a/packages/mitten/README.md
+++ b/packages/mitten/README.md
@@ -1,0 +1,15 @@
+# @ombro/mitten
+
+![npm package](https://badgen.net/npm/v/@ombro/mitten)
+
+TODO
+
+## Install
+
+```sh
+$ npm install @ombro/mitten
+```
+
+## Usage
+
+TODO

--- a/packages/mitten/README_zh.md
+++ b/packages/mitten/README_zh.md
@@ -1,15 +1,120 @@
 # @ombro/mitten
 
-![npm package](https://badgen.net/npm/v/@ombro/mitten)
+[![npm package](https://badgen.net/npm/v/@ombro/mitten)](https://npmjs.com/package/@ombro/mitten)
 
-TODO
+Mitten 是一个轻量级的 TypeScript 事件发射器库，允许您创建、管理和触发自定义事件。
 
 ## 安装
 
+选择你喜欢的包管理器安装它:
+
 ```sh
-$ npm install @ombro/mitten
+npm install @ombro/mitten
+# or
+pnpm add @ombro/mitten
 ```
 
-## 使用
+## 如何使用？
 
-TODO
+### 创建一个事件发射器
+
+要创建一个事件发射器，您可以使用 `mitten` 函数。它接受一个可选的 `EventHandlerMap` 对象作为参数，该对象是事件类型及其对应事件对象的映射。
+
+```ts
+import mitten from '@ombro/mitten'
+
+type MyEvents = {
+  foo: string
+  bar: number
+}
+
+const emitter = mitten<MyEvents>()
+```
+
+### 注册事件处理程序
+
+要注册事件处理程序，请使用发射器的 `on` 方法。它接受两个参数：要监听的事件类型和在响应事件时执行的回调函数。
+
+```ts
+emitter.on('foo', (event) => {
+  console.log(`接收到值为：${event} 的事件`)
+})
+```
+
+要注册一个通配符事件处理程序，它将对所有事件执行，请使用带有 `'*'` 类型的 `on` 方法，并使用一个带有两个参数的回调函数：事件类型和事件对象。
+
+```ts
+emitter.on('*', (type, event) => {
+  console.log(`接收到 ${type} 事件，值为：${event}`)
+})
+```
+
+### 触发事件
+
+要触发事件，请使用发射器的 `emit` 方法。它接受两个参数：要触发的事件类型和要传递给事件处理程序的事件对象。
+
+```ts
+emitter.emit('foo', 'hello world')
+```
+
+如果您需要触发一个未定义值的事件，请将 `undefined` 作为第二个参数传递给 `emit`。如果事件类型具有可选值，则也可以完全省略第二个参数。
+
+```ts
+type MyEvents = {
+  foo: string
+  bar?: number
+}
+
+emitter.emit('foo', '你好，世界')
+emitter.emit('bar')
+```
+
+### 注销事件处理程序
+
+要注销事件处理程序，请使用发射器的 `off` 方法。它接受两个参数：要注销处理程序的事件类型和可选的回调函数。
+
+```ts
+const handler = (event: string) => {
+  console.log(`接收到值为：${event} 的事件`)
+}
+
+emitter.on('foo', handler)
+
+// 注销特定的处理程序
+emitter.off('foo', handler)
+
+// 注销特定事件类型的所有处理程序
+emitter.off('foo')
+
+// 注销 "*" 通配符事件类型的所有处理程序
+emitter.off('*')
+```
+
+## 示例
+
+```ts
+import mitten from '@ombro/mitten'
+
+type MyEvents = {
+  foo: string
+  bar?: number
+}
+
+const emitter = mitten<MyEvents>()
+
+emitter.on('foo', (event) => {
+  console.log(`接收到 foo 事件，值为：${event}`)
+})
+
+emitter.on('bar', (event) => {
+  console.log(`接收到 bar 事件，值为：${event}`)
+})
+
+emitter.on('*', (type, event) => {
+  console.log(`接收到 ${type} 事件，值为：${event}`)
+})
+
+emitter.emit('foo', 'hello world')
+emitter.emit('bar', 42)
+emitter.emit('bar')
+```

--- a/packages/mitten/README_zh.md
+++ b/packages/mitten/README_zh.md
@@ -1,0 +1,15 @@
+# @ombro/mitten
+
+![npm package](https://badgen.net/npm/v/@ombro/mitten)
+
+TODO
+
+## 安装
+
+```sh
+$ npm install @ombro/mitten
+```
+
+## 使用
+
+TODO

--- a/packages/mitten/package.json
+++ b/packages/mitten/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@ombro/mitten",
+  "version": "0.0.1",
+  "description": "Tiny functional event emitter",
+  "author": "Cphayim <i@cphayim.me>",
+  "homepage": "https://github.com/Cphayim/ombro#readme",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.js",
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Cphayim/ombro.git",
+    "directory": "packages/mitten"
+  },
+  "scripts": {
+    "dev": "tsc -w",
+    "build": "tsc",
+    "clean": "rimraf dist coverage *.tsbuildinfo",
+    "prepublish": "pnpm run clean && pnpm run build"
+  },
+  "bugs": {
+    "url": "https://github.com/Cphayim/ombro/issues"
+  }
+}

--- a/packages/mitten/package.json
+++ b/packages/mitten/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ombro/mitten",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Tiny functional event emitter",
   "author": "Cphayim <i@cphayim.me>",
   "homepage": "https://github.com/Cphayim/ombro#readme",

--- a/packages/mitten/package.json
+++ b/packages/mitten/package.json
@@ -7,6 +7,14 @@
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "dist"
   ],
@@ -20,8 +28,8 @@
     "directory": "packages/mitten"
   },
   "scripts": {
-    "dev": "tsc -w",
-    "build": "tsc",
+    "dev": "vite build --watch",
+    "build": "vite build && tsc --declaration --emitDeclarationOnly",
     "clean": "rimraf dist coverage *.tsbuildinfo",
     "prepublish": "pnpm run clean && pnpm run build"
   },

--- a/packages/mitten/src/__tests__/index.spec.ts
+++ b/packages/mitten/src/__tests__/index.spec.ts
@@ -1,0 +1,220 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import defaultMitten, { type Emitter, type EventHandlerMap, mitten } from '../index'
+
+describe('mitten', () => {
+  it('should contains named export and default export', () => {
+    expect(defaultMitten).toBeTypeOf('function')
+    expect(mitten).toBeTypeOf('function')
+    expect(defaultMitten).toBe(mitten)
+  })
+
+  it('should accept an optional event handler map', () => {
+    expect(() => mitten()).not.toThrow()
+    expect(() => mitten(new Map())).not.toThrow()
+
+    const map = new Map()
+    const a = vi.fn()
+    const b = vi.fn()
+    map.set('foo', new Set([a, b]))
+
+    const emitter = mitten<{ foo: undefined }>(map)
+
+    emitter.emit('foo')
+
+    expect(a).toHaveBeenCalledOnce()
+    expect(b).toHaveBeenCalledOnce()
+  })
+})
+
+describe('mitten#', () => {
+  const eventType = Symbol('eventType')
+  type Events = {
+    foo: unknown
+    constructor: unknown
+    FOO: unknown
+    bar: unknown
+    Bar: unknown
+    'baz:bat!': unknown
+    'baz:baT!': unknown
+    Foo: unknown
+    [eventType]: unknown
+  }
+
+  let events: EventHandlerMap<Events>, inst: Emitter<Events>
+
+  beforeEach(() => {
+    events = new Map()
+    inst = mitten(events)
+  })
+
+  describe('properties', () => {
+    it('should expose the event handler map', () => {
+      expect(inst).toHaveProperty('all')
+      expect(inst.all).toBe(events)
+    })
+  })
+
+  describe('on()', () => {
+    it('should be a function', () => {
+      expect(inst).toHaveProperty('on')
+      expect(inst.on).toBeTypeOf('function')
+    })
+
+    it('should register handler for new type', () => {
+      const foo = () => void 0
+      inst.on('foo', foo)
+      expect(events.get('foo')?.size).toBe(1)
+      expect(events.get('foo')?.has(foo)).toBe(true)
+    })
+
+    it('should not add duplicate handlers', () => {
+      const foo = () => void 0
+      inst.on('foo', foo)
+      inst.on('foo', foo)
+      inst.on('foo', foo)
+
+      // for an event type, the same callback is registered only once
+      expect(events.get('foo')?.size).toBe(1)
+    })
+
+    it('should register handlers for any type strings', () => {
+      const foo = () => void 0
+      inst.on('test' as any, foo)
+      expect(events.get('test' as any)?.size).toBe(1)
+      expect(events.get('test' as any)?.has(foo)).toBe(true)
+    })
+
+    it('should append handler for existing type', () => {
+      const foo = () => void 0
+      const bar = () => void 0
+      inst.on('foo', foo)
+      inst.on('foo', bar)
+
+      expect(events.get('foo')?.size).toBe(2)
+      expect(events.get('foo')?.has(foo)).toBe(true)
+      expect(events.get('foo')?.has(bar)).toBe(true)
+    })
+
+    it('should NOT normalize case', () => {
+      const foo = () => void 0
+      inst.on('FOO', foo)
+      inst.on('Bar', foo)
+      inst.on('baz:baT!', foo)
+
+      expect(events.has('FOO')).toBe(true)
+      expect(events.get('FOO')!.has(foo)).toBe(true)
+      expect(events.has('foo')).toBe(false)
+
+      expect(events.has('Bar')).toBe(true)
+      expect(events.get('Bar')!.has(foo)).toBe(true)
+      expect(events.has('bar')).toBe(false)
+
+      expect(events.has('baz:baT!')).toBe(true)
+      expect(events.get('baz:baT!')!.has(foo)).toBe(true)
+      expect(events.has('baz:bat!')).toBe(false)
+    })
+
+    it('can take symbols for event types', () => {
+      const foo = () => void 0
+      inst.on(eventType, foo)
+      expect(events.get(eventType)?.size).toBe(1)
+    })
+  })
+
+  describe('off()', () => {
+    it('should be a function', () => {
+      expect(inst).toHaveProperty('off')
+      expect(inst.off).toBeTypeOf('function')
+    })
+
+    it('should remove handler for type', () => {
+      const foo = () => void 0
+      inst.on('foo', foo)
+      inst.off('foo', foo)
+
+      expect(events.has('foo')).toBe(true)
+      expect(events.get('foo')!.size).toBe(0)
+    })
+
+    it('should NOT normalize case', () => {
+      const foo = () => void 0
+      inst.on('FOO', foo)
+      inst.on('Bar', foo)
+      inst.on('baz:bat!', foo)
+
+      inst.off('FOO', foo)
+      inst.off('Bar', foo)
+      inst.off('baz:baT!', foo)
+
+      expect(events.get('FOO')?.size).toBe(0)
+      expect(events.has('foo')).toBe(false)
+      expect(events.get('Bar')?.size).toBe(0)
+      expect(events.has('bar')).toBe(false)
+      expect(events.get('baz:bat!')?.size).toBe(1)
+    })
+
+    it('off("type") should remove all handlers of the given type', () => {
+      inst.on('foo', () => void 0)
+      inst.on('foo', () => void 0)
+      inst.on('bar', () => void 0)
+
+      expect(events.get('foo')?.size).toBe(2)
+      inst.off('foo')
+      expect(events.get('foo')?.size).toBe(0)
+
+      expect(events.get('bar')?.size).toBe(1)
+      inst.off('bar')
+      expect(events.get('bar')?.size).toBe(0)
+    })
+  })
+
+  describe('emit()', () => {
+    it('should be a function', () => {
+      expect(inst).toHaveProperty('emit')
+      expect(inst.emit).toBeTypeOf('function')
+    })
+
+    it('should invoke handler for type', () => {
+      const event = { a: 'b' }
+
+      inst.on('foo', (one, two?: unknown) => {
+        expect(one).toEqual(event)
+        expect(two).toBe(undefined)
+      })
+
+      inst.emit('foo', event)
+    })
+
+    it('should NOT ignore case', () => {
+      const onFoo = vi.fn(),
+        onFOO = vi.fn()
+      events.set('Foo', new Set([onFoo]))
+      events.set('FOO', new Set([onFOO]))
+
+      inst.emit('Foo', 'Foo arg')
+      inst.emit('FOO', 'FOO arg')
+
+      expect(onFoo).toBeCalledWith('Foo arg')
+      expect(onFOO).toBeCalledWith('FOO arg')
+    })
+
+    it('should invoke * handlers', () => {
+      const star = vi.fn(),
+        ea = { a: 'a' },
+        eb = { b: 'b' }
+
+      events.set('*', new Set([star]))
+
+      inst.emit('foo', ea)
+      expect(star).toHaveBeenCalledOnce()
+      expect(star).toHaveBeenCalledWith('foo', ea)
+
+      star.mockReset()
+
+      inst.emit('bar', eb)
+      expect(star).toHaveBeenCalledOnce()
+      expect(star).toHaveBeenCalledWith('bar', eb)
+    })
+  })
+})

--- a/packages/mitten/src/index.ts
+++ b/packages/mitten/src/index.ts
@@ -1,3 +1,104 @@
-export function example() {
-  return 'Hello world'
+export type EventType = string | symbol
+
+export type Handle<T = unknown> = (event: T) => void
+export type WildcardHandle<T = Record<string, unknown>> = (type: keyof T, event: T[keyof T]) => void
+
+// An set of all currently registered event handlers for a type
+export type EventHandlerSet<T = unknown> = Set<Handle<T>>
+export type WildcardEventHandlerSet<T = Record<string, unknown>> = Set<WildcardHandle<T>>
+
+// A map of event types and their corresponding event handlers.
+export type EventHandlerMap<Events extends Record<EventType, unknown>> = Map<
+  keyof Events | '*',
+  EventHandlerSet<Events[keyof Events]> | WildcardEventHandlerSet<Events>
+>
+
+export interface Emitter<Events extends Record<EventType, unknown>> {
+  all: EventHandlerMap<Events>
+
+  on<Key extends keyof Events>(type: Key, handler: Handle<Events[Key]>): void
+  on(type: '*', handler: WildcardHandle<Events>): void
+
+  off<Key extends keyof Events>(type: Key, handler?: Handle<Events[Key]>): void
+  off(type: '*', handler: WildcardHandle<Events>): void
+
+  emit<Key extends keyof Events>(type: Key, event: Events[Key]): void
+  emit<Key extends keyof Events>(type: undefined extends Events[Key] ? Key : never): void
 }
+
+export function mitten<Events extends Record<EventType, unknown>>(
+  all?: EventHandlerMap<Events>,
+): Emitter<Events> {
+  type GenericEventHandler = Handle<Events[keyof Events]> | WildcardHandle<Events>
+
+  all ??= new Map()
+
+  return {
+    /**
+     * A Map of event types to registered handler functions
+     */
+    all,
+
+    /**
+     * Register an event handler for the given type.
+     * @param type type of event to listen for, or '*' for all events
+     * @param handler callback in response to given event
+     */
+    on<Key extends keyof Events>(type: Key, handler: GenericEventHandler) {
+      const handlers = all!.get(type) as Set<GenericEventHandler> | undefined
+
+      if (handlers) {
+        handlers.add(handler)
+      } else {
+        all!.set(type, new Set([handler]) as EventHandlerSet<Events[keyof Events]>)
+      }
+    },
+
+    /**
+     * Remove an event handler for the given type.
+     * If `handler` is omitted, all handlers of the given type are removed.
+     * @param type type of event to unregister `handler` from (`'*'` to remove a wildcard handler)
+     * @param handler callback to remove
+     * @returns
+     */
+
+    off<Key extends keyof Events>(type: Key, handler?: GenericEventHandler) {
+      const handlers = all!.get(type) as Set<GenericEventHandler> | undefined
+
+      if (!handlers) return
+
+      if (handler) {
+        handlers.delete(handler)
+      } else {
+        handlers.clear()
+      }
+    },
+
+    /**
+     * Invoke all handlers for the given event type.
+     * If present, `'*'` handlers are invoked for all event types.
+     *
+     * Note: Manually firing '*' handlers is not supported.
+     *
+     * @param type the event type to invoke
+     * @param event any value (object is recommended and powerful), passed to each handler
+     */
+    emit<Key extends keyof Events>(type: Key, event?: Events[Key]) {
+      const handlers = all!.get(type) as EventHandlerSet<Events[keyof Events]> | undefined
+      if (handlers) {
+        handlers.forEach((handler) => {
+          handler(event!)
+        })
+      }
+
+      const wildcardHandlers = all!.get('*') as WildcardEventHandlerSet<Events> | undefined
+      if (wildcardHandlers) {
+        wildcardHandlers.forEach((handler) => {
+          handler(type, event!)
+        })
+      }
+    },
+  }
+}
+
+export default mitten

--- a/packages/mitten/src/index.ts
+++ b/packages/mitten/src/index.ts
@@ -1,0 +1,3 @@
+export function example() {
+  return 'Hello world'
+}

--- a/packages/mitten/tsconfig.json
+++ b/packages/mitten/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__/**"]
+}

--- a/packages/mitten/vite.config.ts
+++ b/packages/mitten/vite.config.ts
@@ -4,9 +4,6 @@ import { createBuild } from '../../scripts/vite.base.config'
 
 export default defineConfig(({ mode }) => {
   const build = createBuild({ mode, root: __dirname })
-  build.rollupOptions = {
-    external: ['vue'],
-  }
 
   const config: UserConfigExport = {
     build,

--- a/packages/node/src/__tests__/engine.test.ts
+++ b/packages/node/src/__tests__/engine.test.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 
-describe.skip('@ombro/node', () => {
+describe('@ombro/node', () => {
   beforeAll(() => {
     vi.spyOn(console, 'log').mockImplementation(() => void 0)
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^5.56.0
         version: 5.56.0(eslint@8.36.0)(typescript@5.1.3)
       '@vitest/coverage-c8':
-        specifier: ^0.29.7
-        version: 0.29.7(vitest@0.29.7)
+        specifier: ^0.31.4
+        version: 0.31.4(vitest@0.31.4)
       commitizen:
         specifier: ^4.3.0
         version: 4.3.0
@@ -87,8 +87,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0(@types/node@18.15.5)(vite@4.2.1)
       vitest:
-        specifier: ^0.29.7
-        version: 0.29.7
+        specifier: ^0.31.4
+        version: 0.31.4
       vue-tsc:
         specifier: ^1.6.5
         version: 1.6.5(typescript@5.1.3)
@@ -321,6 +321,8 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1
 
+  packages/mitten: {}
+
   packages/node:
     dependencies:
       '@babel/core':
@@ -391,6 +393,14 @@ packages:
       '@jridgewell/gen-mapping': 0.1.1
       '@jridgewell/trace-mapping': 0.3.17
     dev: false
+
+  /@ampproject/remapping@2.2.1:
+    resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.2
+      '@jridgewell/trace-mapping': 0.3.17
+    dev: true
 
   /@babel/code-frame@7.18.6:
     resolution: {integrity: sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==}
@@ -2654,11 +2664,11 @@ packages:
   /@types/chai-subset@1.3.3:
     resolution: {integrity: sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==}
     dependencies:
-      '@types/chai': 4.3.4
+      '@types/chai': 4.3.5
     dev: true
 
-  /@types/chai@4.3.4:
-    resolution: {integrity: sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==}
+  /@types/chai@4.3.5:
+    resolution: {integrity: sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==}
     dev: true
 
   /@types/dedent@0.7.0:
@@ -2968,44 +2978,54 @@ packages:
       '@typescript-eslint/types': 5.56.0
       eslint-visitor-keys: 3.3.0
 
-  /@vitest/coverage-c8@0.29.7(vitest@0.29.7):
-    resolution: {integrity: sha512-TSubtP9JFBuI/wuApxwknHe40VDkX8hFbBak0OXj4/jCeXrEu5B5GPWcxzyk9YvzXgCaDvoiZV79I7AvhNI9YQ==}
+  /@vitest/coverage-c8@0.31.4(vitest@0.31.4):
+    resolution: {integrity: sha512-VPx368m4DTcpA/P0v3YdVxl4QOSh1DbUcXURLRvDShrIB5KxOgfzw4Bn2R8AhAe/GyiWW/FIsJ/OJdYXCCiC1w==}
     peerDependencies:
-      vitest: '>=0.29.0 <1'
+      vitest: '>=0.30.0 <1'
     dependencies:
+      '@ampproject/remapping': 2.2.1
       c8: 7.13.0
+      magic-string: 0.30.0
       picocolors: 1.0.0
       std-env: 3.3.2
-      vitest: 0.29.7
+      vitest: 0.31.4
     dev: true
 
-  /@vitest/expect@0.29.7:
-    resolution: {integrity: sha512-UtG0tW0DP6b3N8aw7PHmweKDsvPv4wjGvrVZW7OSxaFg76ShtVdMiMcUkZJgCE8QWUmhwaM0aQhbbVLo4F4pkA==}
+  /@vitest/expect@0.31.4:
+    resolution: {integrity: sha512-tibyx8o7GUyGHZGyPgzwiaPaLDQ9MMuCOrc03BYT0nryUuhLbL7NV2r/q98iv5STlwMgaKuFJkgBW/8iPKwlSg==}
     dependencies:
-      '@vitest/spy': 0.29.7
-      '@vitest/utils': 0.29.7
+      '@vitest/spy': 0.31.4
+      '@vitest/utils': 0.31.4
       chai: 4.3.7
     dev: true
 
-  /@vitest/runner@0.29.7:
-    resolution: {integrity: sha512-Yt0+csM945+odOx4rjZSjibQfl2ymxqVsmYz6sO2fiO5RGPYDFCo60JF6tLL9pz4G/kjY4irUxadeB1XT+H1jg==}
+  /@vitest/runner@0.31.4:
+    resolution: {integrity: sha512-Wgm6UER+gwq6zkyrm5/wbpXGF+g+UBB78asJlFkIOwyse0pz8lZoiC6SW5i4gPnls/zUcPLWS7Zog0LVepXnpg==}
     dependencies:
-      '@vitest/utils': 0.29.7
+      '@vitest/utils': 0.31.4
+      concordance: 5.0.4
       p-limit: 4.0.0
       pathe: 1.1.0
     dev: true
 
-  /@vitest/spy@0.29.7:
-    resolution: {integrity: sha512-IalL0iO6A6Xz8hthR8sctk6ZS//zVBX48EiNwQguYACdgdei9ZhwMaBFV70mpmeYAFCRAm+DpoFHM5470Im78A==}
+  /@vitest/snapshot@0.31.4:
+    resolution: {integrity: sha512-LemvNumL3NdWSmfVAMpXILGyaXPkZbG5tyl6+RQSdcHnTj6hvA49UAI8jzez9oQyE/FWLKRSNqTGzsHuk89LRA==}
     dependencies:
-      tinyspy: 1.0.2
+      magic-string: 0.30.0
+      pathe: 1.1.0
+      pretty-format: 27.5.1
     dev: true
 
-  /@vitest/utils@0.29.7:
-    resolution: {integrity: sha512-vNgGadp2eE5XKCXtZXL5UyNEDn68npSct75OC9AlELenSK0DiV1Mb9tfkwJHKjRb69iek+e79iipoJx8+s3SdA==}
+  /@vitest/spy@0.31.4:
+    resolution: {integrity: sha512-3ei5ZH1s3aqbEyftPAzSuunGICRuhE+IXOmpURFdkm5ybUADk+viyQfejNk6q8M5QGX8/EVKw+QWMEP3DTJDag==}
     dependencies:
-      cli-truncate: 3.1.0
-      diff: 5.1.0
+      tinyspy: 2.1.1
+    dev: true
+
+  /@vitest/utils@0.31.4:
+    resolution: {integrity: sha512-DobZbHacWznoGUfYU8XDPY78UubJxXfMNY1+SUdOp1NsI34eopSA6aZMeaGu10waSOeYwE8lxrd/pLfT0RMxjQ==}
+    dependencies:
+      concordance: 5.0.4
       loupe: 2.3.6
       pretty-format: 27.5.1
     dev: true
@@ -3435,6 +3455,10 @@ packages:
       inherits: 2.0.4
       readable-stream: 3.6.0
 
+  /blueimp-md5@2.19.0:
+    resolution: {integrity: sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==}
+    dev: true
+
   /boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
     dev: false
@@ -3783,6 +3807,20 @@ packages:
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  /concordance@5.0.4:
+    resolution: {integrity: sha512-OAcsnTEYu1ARJqWVGwf4zh4JDfHZEaSNlNccFmt8YjB2l/n19/PF2viLINHc57vO4FKIAFl2FWASIGZZWZ2Kxw==}
+    engines: {node: '>=10.18.0 <11 || >=12.14.0 <13 || >=14'}
+    dependencies:
+      date-time: 3.1.0
+      esutils: 2.0.3
+      fast-diff: 1.2.0
+      js-string-escape: 1.0.1
+      lodash: 4.17.21
+      md5-hex: 3.0.1
+      semver: 7.5.0
+      well-known-symbols: 2.0.0
+    dev: true
+
   /conventional-changelog-angular@5.0.13:
     resolution: {integrity: sha512-i/gipMxs7s8L/QeuavPF2hLnJgH6pEZAttySB6aiQLWcX3puWDL3ACVmvBhJGxnAy52Qc15ua26BufY6KpmrVA==}
     engines: {node: '>=10'}
@@ -3940,6 +3978,13 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /date-time@3.1.0:
+    resolution: {integrity: sha512-uqCUKXE5q1PNBXjPqvwhwJf9SwMoAHBgWJ6DcrnS5o+W2JOiIILl0JEdVD8SGujrNS02GGxgwAg2PN2zONgtjg==}
+    engines: {node: '>=6'}
+    dependencies:
+      time-zone: 1.0.0
+    dev: true
+
   /de-indent@1.0.2:
     resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
     dev: true
@@ -4003,11 +4048,6 @@ packages:
 
   /diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
-    engines: {node: '>=0.3.1'}
-    dev: true
-
-  /diff@5.1.0:
-    resolution: {integrity: sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==}
     engines: {node: '>=0.3.1'}
     dev: true
 
@@ -4627,7 +4667,6 @@ packages:
 
   /fast-diff@1.2.0:
     resolution: {integrity: sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==}
-    dev: false
 
   /fast-glob@3.2.12:
     resolution: {integrity: sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==}
@@ -5389,6 +5428,11 @@ packages:
   /js-sdsl@4.2.0:
     resolution: {integrity: sha512-dyBIzQBDkCqCu+0upx25Y2jGdbTGxE9fshMsCdK0ViOongpV+n5tXRcZY9v7CaVQ79AGS9KA1KHtojxiM7aXSQ==}
 
+  /js-string-escape@1.0.1:
+    resolution: {integrity: sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==}
+    engines: {node: '>= 0.8'}
+    dev: true
+
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -5548,8 +5592,8 @@ packages:
       strip-bom: 3.0.0
     dev: true
 
-  /local-pkg@0.4.2:
-    resolution: {integrity: sha512-mlERgSPrbxU3BP4qBqAvvwlgW4MTg78iwJdGGnv7kibKjWcJksrG3t6LB5lXI93wXRDvG4NpUgJFmTG4T6rdrg==}
+  /local-pkg@0.4.3:
+    resolution: {integrity: sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==}
     engines: {node: '>=14'}
     dev: true
 
@@ -5749,6 +5793,13 @@ packages:
   /mathml-tag-names@2.1.3:
     resolution: {integrity: sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==}
 
+  /md5-hex@3.0.1:
+    resolution: {integrity: sha512-BUiRtTtV39LIJwinWBjqVsU9xhdnz7/i889V859IBFpuqGAj6LuOvHv5XLbgZ2R7ptJoJaEcxkv88/h25T7Ciw==}
+    engines: {node: '>=8'}
+    dependencies:
+      blueimp-md5: 2.19.0
+    dev: true
+
   /mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
 
@@ -5891,13 +5942,13 @@ packages:
     hasBin: true
     dev: true
 
-  /mlly@1.1.0:
-    resolution: {integrity: sha512-cwzBrBfwGC1gYJyfcy8TcZU1f+dbH/T+TuOhtYP2wLv/Fb51/uV7HJQfBPtEupZ2ORLRU1EKFS/QfS3eo9+kBQ==}
+  /mlly@1.3.0:
+    resolution: {integrity: sha512-HT5mcgIQKkOrZecOjOX3DJorTikWXwsBfpcr/MGBkhfWcjiqvnaL/9ppxvIUXfjT6xt4DVIAsN9fMUz1ev4bIw==}
     dependencies:
       acorn: 8.8.2
       pathe: 1.1.0
-      pkg-types: 1.0.1
-      ufo: 1.0.1
+      pkg-types: 1.0.3
+      ufo: 1.1.2
     dev: true
 
   /ms@2.1.2:
@@ -6274,11 +6325,11 @@ packages:
       find-up: 4.1.0
     dev: true
 
-  /pkg-types@1.0.1:
-    resolution: {integrity: sha512-jHv9HB+Ho7dj6ItwppRDDl0iZRYBD0jsakHXtFgoLr+cHSF6xC+QL54sJmWxyGxOLYSHm0afhXhXcQDQqH9z8g==}
+  /pkg-types@1.0.3:
+    resolution: {integrity: sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==}
     dependencies:
       jsonc-parser: 3.2.0
-      mlly: 1.1.0
+      mlly: 1.3.0
       pathe: 1.1.0
     dev: true
 
@@ -7265,17 +7316,22 @@ packages:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
     dev: true
 
-  /tinybench@2.3.1:
-    resolution: {integrity: sha512-hGYWYBMPr7p4g5IarQE7XhlyWveh1EKhy4wUBS1LrHXCKYgvz+4/jCqgmJqZxxldesn05vccrtME2RLLZNW7iA==}
+  /time-zone@1.0.0:
+    resolution: {integrity: sha512-TIsDdtKo6+XrPtiTm1ssmMngN1sAhyKnTO2kunQWqNPWIVvCm15Wmw4SWInwTVgJ5u/Tr04+8Ei9TNcw4x4ONA==}
+    engines: {node: '>=4'}
     dev: true
 
-  /tinypool@0.4.0:
-    resolution: {integrity: sha512-2ksntHOKf893wSAH4z/+JbPpi92esw8Gn9N2deXX+B0EO92hexAVI9GIZZPx7P5aYo5KULfeOSt3kMOmSOy6uA==}
+  /tinybench@2.5.0:
+    resolution: {integrity: sha512-kRwSG8Zx4tjF9ZiyH4bhaebu+EDz1BOx9hOigYHlUW4xxI/wKIUQUqo018UlU4ar6ATPBsaMrdbKZ+tmPdohFA==}
+    dev: true
+
+  /tinypool@0.5.0:
+    resolution: {integrity: sha512-paHQtnrlS1QZYKF/GnLoOM/DN9fqaGOFbCbxzAhwniySnzl9Ebk8w73/dd34DAhe/obUbPAOldTyYXQZxnPBPQ==}
     engines: {node: '>=14.0.0'}
     dev: true
 
-  /tinyspy@1.0.2:
-    resolution: {integrity: sha512-bSGlgwLBYf7PnUsQ6WOc6SJ3pGOcd+d8AA6EUnLDDM0kWEstC1JIlSZA3UNliDXhd9ABoS7hiRBDCu+XP/sf1Q==}
+  /tinyspy@2.1.1:
+    resolution: {integrity: sha512-XPJL2uSzcOyBMky6OFrusqWlzfFrXtE0hPuMgW8A2HmaqrPo4ZQHRN/V0QXN3FSjKxpsbRrFc5LI7KOwBsT1/w==}
     engines: {node: '>=14.0.0'}
     dev: true
 
@@ -7460,8 +7516,8 @@ packages:
     hasBin: true
     dev: true
 
-  /ufo@1.0.1:
-    resolution: {integrity: sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==}
+  /ufo@1.1.2:
+    resolution: {integrity: sha512-TrY6DsjTQQgyS3E3dBaOXf0TpPD8u9FVrVYmKVegJuFw51n/YB9XPt+U6ydzFG5ZIN7+DIjPbNmXoBj9esYhgQ==}
     dev: true
 
   /unbox-primitive@1.0.2:
@@ -7563,14 +7619,14 @@ packages:
     engines: {node: '>= 0.10'}
     dev: true
 
-  /vite-node@0.29.7(@types/node@18.15.5):
-    resolution: {integrity: sha512-PakCZLvz37yFfUPWBnLa1OYHPCGm5v4pmRrTcFN4V/N/T3I6tyP3z07S//9w+DdeL7vVd0VSeyMZuAh+449ZWw==}
-    engines: {node: '>=v14.16.0'}
+  /vite-node@0.31.4(@types/node@18.15.5):
+    resolution: {integrity: sha512-uzL377GjJtTbuc5KQxVbDu2xfU/x0wVjUtXQR2ihS21q/NK6ROr4oG0rsSkBBddZUVCwzfx22in76/0ZZHXgkQ==}
+    engines: {node: '>=v14.18.0'}
     hasBin: true
     dependencies:
       cac: 6.7.14
       debug: 4.3.4
-      mlly: 1.1.0
+      mlly: 1.3.0
       pathe: 1.1.0
       picocolors: 1.0.0
       vite: 4.2.1(@types/node@18.15.5)
@@ -7641,9 +7697,9 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vitest@0.29.7:
-    resolution: {integrity: sha512-aWinOSOu4jwTuZHkb+cCyrqQ116Q9TXaJrNKTHudKBknIpR0VplzeaOUuDF9jeZcrbtQKZQt6yrtd+eakbaxHg==}
-    engines: {node: '>=v14.16.0'}
+  /vitest@0.31.4:
+    resolution: {integrity: sha512-GoV0VQPmWrUFOZSg3RpQAPN+LPmHg2/gxlMNJlyxJihkz6qReHDV6b0pPDcqFLNEPya4tWJ1pgwUNP9MLmUfvQ==}
+    engines: {node: '>=v14.18.0'}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
@@ -7651,6 +7707,7 @@ packages:
       '@vitest/ui': '*'
       happy-dom: '*'
       jsdom: '*'
+      playwright: '*'
       safaridriver: '*'
       webdriverio: '*'
     peerDependenciesMeta:
@@ -7664,34 +7721,37 @@ packages:
         optional: true
       jsdom:
         optional: true
+      playwright:
+        optional: true
       safaridriver:
         optional: true
       webdriverio:
         optional: true
     dependencies:
-      '@types/chai': 4.3.4
+      '@types/chai': 4.3.5
       '@types/chai-subset': 1.3.3
       '@types/node': 18.15.5
-      '@vitest/expect': 0.29.7
-      '@vitest/runner': 0.29.7
-      '@vitest/spy': 0.29.7
-      '@vitest/utils': 0.29.7
+      '@vitest/expect': 0.31.4
+      '@vitest/runner': 0.31.4
+      '@vitest/snapshot': 0.31.4
+      '@vitest/spy': 0.31.4
+      '@vitest/utils': 0.31.4
       acorn: 8.8.2
       acorn-walk: 8.2.0
       cac: 6.7.14
       chai: 4.3.7
+      concordance: 5.0.4
       debug: 4.3.4
-      local-pkg: 0.4.2
+      local-pkg: 0.4.3
+      magic-string: 0.30.0
       pathe: 1.1.0
       picocolors: 1.0.0
-      source-map: 0.6.1
       std-env: 3.3.2
       strip-literal: 1.0.1
-      tinybench: 2.3.1
-      tinypool: 0.4.0
-      tinyspy: 1.0.2
+      tinybench: 2.5.0
+      tinypool: 0.5.0
       vite: 4.2.1(@types/node@18.15.5)
-      vite-node: 0.29.7(@types/node@18.15.5)
+      vite-node: 0.31.4(@types/node@18.15.5)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less
@@ -7782,6 +7842,11 @@ packages:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
     dependencies:
       defaults: 1.0.3
+
+  /well-known-symbols@2.0.0:
+    resolution: {integrity: sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q==}
+    engines: {node: '>=6'}
+    dev: true
 
   /which-boxed-primitive@1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,11 +4,7 @@ export default defineConfig({
   test: {
     root: __dirname,
     environment: 'node',
-    include: [
-      'packages/**/__tests__/**/*.ts',
-      'packages/**/*.{spec,test}.ts',
-      '!**/*.d.ts', //
-    ],
+    include: ['packages/**/*.{spec,test}.ts'],
     coverage: {
       include: ['packages/**/src/**/*.ts'],
       reporter: ['text', 'json'],


### PR DESCRIPTION
## Affected packages

- **@ombro/mitten**

Mitten is a lightweight event emitter library for TypeScript that allows you to create, manage, and emit custom events.

## Installation

Use your favorite package manager to install it:

```sh
npm install @ombro/mitten
# or
pnpm add @ombro/mitten
```

## Usage

### Creating an Emitter

To create an emitter, you can use the `mitten` function. It takes an optional `EventHandlerMap` object as an argument, which is a map of event types and their corresponding event object.

```ts
import mitten from '@ombro/mitten'

type MyEvents = {
  foo: string
  bar: number
}

const emitter = mitten<MyEvents>()
```

### Registering Event Handlers

To register an event handler, use the `on` method of the emitter. It takes two arguments: the event type to listen for, and the callback function to execute in response to the event.

```ts
emitter.on('foo', (event) => {
  console.log(`Received event with value: ${event}`)
})
```

To register a wildcard event handler that will execute for all events, use the `on` method with a `'*'` type and a callback that takes two arguments: the event type and the event object.

```ts
emitter.on('*', (type, event) => {
  console.log(`Received ${type} event with value: ${event}`)
})
```

### Emitting Events

To emit an event, use the `emit` method of the emitter. It takes two arguments: the event type to emit, and the event object to pass to the event handlers.

```ts
emitter.emit('foo', 'hello world')
```

If you need to emit an event with an undefined value, pass `undefined` as the second argument to `emit`. You can also omit the second argument entirely if the event type has an optional value.

```ts
type MyEvents = {
  foo: string
  bar?: number
}

emitter.emit('foo', 'hello world')
emitter.emit('bar')
```

### Unregistering Event Handlers

To unregister an event handler, use the `off` method of the emitter. It takes two arguments: the event type to unregister the handler from, and the optional callback function to remove.

```ts
const handler = (event: string) => {
  console.log(`Received event with value: ${event}`)
}

emitter.on('foo', handler)

// Unregister a specific handler
emitter.off('foo', handler)

// Unregister all handlers for a specific event type
emitter.off('foo')

// Unregister all handlers for wildcard event types
emitter.off('*')
```

## Example

```ts
import mitten from '@ombro/mitten'

type MyEvents = {
  foo: string
  bar?: number
}

const emitter = mitten<MyEvents>()

emitter.on('foo', (event) => {
  console.log(`Received foo event with value: ${event}`)
})

emitter.on('bar', (event) => {
  console.log(`Received bar event with value: ${event}`)
})

emitter.on('*', (type, event) => {
  console.log(`Received ${type} event with value: ${event}`)
})

emitter.emit('foo', 'hello world')
emitter.emit('bar', 42)
emitter.emit('bar')
```
